### PR TITLE
snapShot 방식으로, UI 테스트하는 법

### DIFF
--- a/src/pages/cart/components/tests/PageTitle.spec.jsx
+++ b/src/pages/cart/components/tests/PageTitle.spec.jsx
@@ -3,6 +3,26 @@ import React from 'react';
 import PageTitle from '@/pages/cart/components/PageTitle';
 import render from '@/utils/test/render';
 
-it('pageTitle 스냅샷 테스트(toMatchInlineSnapshot)', async () => {});
+/**
+ * toMatchInlineSnapshot?
+ * - 테스트 파일과 스냅샷 파일을 하나의 파일로 관리한다.
+ * - 스냅샷 파일은 테스트 파일이 실행될 때 생성된다.
+ * */
 
-it('pageTitle 스냅샷 테스트(toMatchSnapshot)', async () => {});
+it('pageTitle 스냅샷 테스트(toMatchInlineSnapshot)', async () => {
+  // container는 렌더링 결과를 div로 감싸서 반환한다.
+  const { container } = await render(<PageTitle />);
+
+  expect(container).toMatchInlineSnapshot();
+});
+
+/**
+ * toMatchSnapshot?
+ * - 테스트 파일과 스냅샷 파일을 별도로 분리해서 관리한다.
+ * - 스냅샷 파일은 테스트 파일이 실행될 때 생성된다.
+ */
+it('pageTitle 스냅샷 테스트(toMatchSnapshot)', async () => {
+  const { container } = await render(<PageTitle />);
+
+  expect(container).toMatchSnapshot();
+});

--- a/src/pages/cart/components/tests/PageTitle.spec.jsx
+++ b/src/pages/cart/components/tests/PageTitle.spec.jsx
@@ -13,12 +13,23 @@ it('pageTitle 스냅샷 테스트(toMatchInlineSnapshot)', async () => {
   // container는 렌더링 결과를 div로 감싸서 반환한다.
   const { container } = await render(<PageTitle />);
 
-  expect(container).toMatchInlineSnapshot();
+  expect(container).toMatchInlineSnapshot(`
+    <div>
+      <h1
+        class="MuiTypography-root MuiTypography-h4 css-1lnl64-MuiTypography-root"
+      >
+        상품 리스트
+      </h1>
+      <div
+        style="position: fixed; z-index: 9999; top: 16px; left: 16px; right: 16px; bottom: 16px; pointer-events: none;"
+      />
+    </div>
+  `);
 });
 
 /**
  * toMatchSnapshot?
- * - 테스트 파일과 스냅샷 파일을 별도로 분리해서 관리한다.
+ * - 테스트 파일과 스냅샷 파일을 별도로 분리해서 관리한다.(PageTitle.spec.jsx.snap)
  * - 스냅샷 파일은 테스트 파일이 실행될 때 생성된다.
  */
 it('pageTitle 스냅샷 테스트(toMatchSnapshot)', async () => {

--- a/src/pages/cart/components/tests/__snapshots__/PageTitle.spec.jsx.snap
+++ b/src/pages/cart/components/tests/__snapshots__/PageTitle.spec.jsx.snap
@@ -1,0 +1,14 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`pageTitle 스냅샷 테스트(toMatchSnapshot) 1`] = `
+<div>
+  <h1
+    class="MuiTypography-root MuiTypography-h4 css-1lnl64-MuiTypography-root"
+  >
+    상품 리스트
+  </h1>
+  <div
+    style="position: fixed; z-index: 9999; top: 16px; left: 16px; right: 16px; bottom: 16px; pointer-events: none;"
+  />
+</div>
+`;

--- a/src/utils/common.spec.js
+++ b/src/utils/common.spec.js
@@ -11,7 +11,21 @@ describe('pick util 단위테스트', () => {
     expect(pick(obj, 'a')).toEqual({ a: 'A' });
   });
 
-  it('단일 인자로 전달된 키의 값을 객체에 담아 반환한다(snapshots)', () => {});
+  it('단일 인자로 전달된 키의 값을 객체에 담아 반환한다(snapshots)', () => {
+    const obj = {
+      a: 'A',
+      b: { c: 'C' },
+      d: null,
+    };
+
+    expect(pick(obj, 'b')).toMatchInlineSnapshot(`
+      {
+        "b": {
+          "c": "C",
+        },
+      }
+    `);
+  });
 
   it('2개 이상의 인자로 전달된 키의 값을 객체에 담아 반환한다', () => {
     const obj = {


### PR DESCRIPTION
### 컴포넌트를 shapshot 테스트하는 법
- [1. snapShot 코드 작성](https://github.com/KumJungMin/testcode-basic/pull/6/commits/bbd7c693b41e2dc8515228a2804d2665152eab8c)
- [2. run test 실행시, 현재 구현을 기준으로 dom이 기록됨](https://github.com/KumJungMin/testcode-basic/pull/6/commits/d11c548d71e8fe0eb0aa725e616cc8bb7a2f63eb)

### 유틸 함수를 shapshot 테스트하는 법
- [3. 유틸함수로 스냅샷 테스트가 가능](https://github.com/KumJungMin/testcode-basic/pull/6/commits/d878c20f9d63d8102c06a859ae8b79b033b6f24a)
- 장점
	- 모든 프로퍼티의 기대값을 직접 입력하지 않고도 빠르게 테스트를 작성하여 검증할 수 있음
	- 많은 프로퍼티를 검증하는 테스트가 필요할 때 스냅샷 테스트를 사용하면 유용