### PR TITLE
크로마틱과 시각적 회귀테스트

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,8 @@
 # https://www.chromatic.com/docs/github-actions
+# 이 파일은 chromatic에 PR이 올라올 때마다 자동으로 스토리북을 업로드하는 workflow 파일입니다.
+
 name: 'chromatic test'
-on: pull_request
+on: pull_request # 실제 적용시에는 메인 브렌치의 푸시가 발생했을 때 실행되도록 변경해야 합니다.
 jobs:
   chromatic-deployment:
     runs-on: ubuntu-latest
@@ -14,7 +16,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Publish to Chromatic
+        # 기본적으로 프로젝트의 build:storybook을 실행하여 스토리북을 빌드하고 chromatic에 업로드합니다.
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }} # https://www.chromatic.com/docs/github-actions/
-          onlyChanged: true # https://www.chromatic.com/docs/turbosnap/#turbosnap
+          onlyChanged: true
+          # https://www.chromatic.com/docs/turbosnap/#turbosnap
+          # onlyChanged 옵션을 사용하면 변경된 스토리만 업로드합니다.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "eslint": "eslint 'src/**/*.js' 'src/**/*.jsx'",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "chromatic": "npx chromatic --project-token=토큰입력"
+    "chromatic": "npx chromatic --project-token=크로마틱_토큰_입력"
   },
   "dependencies": {
     "@mui/icons-material": "^5.11.9",

--- a/src/pages/cart/components/PageTitle.jsx
+++ b/src/pages/cart/components/PageTitle.jsx
@@ -2,7 +2,7 @@ import { Typography } from '@mui/material';
 import React from 'react';
 
 const PageTitle = () => (
-  <Typography variant="h4" component="h1" padding="20px 0">
+  <Typography variant="h4" component="h1" padding="20px 0" color="red">
     상품 리스트
   </Typography>
 );


### PR DESCRIPTION
### chromatic을 써야하는 이유
- 전문적인 도구를 사용해 시각적 회귀 테스트를 실행하는 것이 좋다
	- 일관된 환경에서 스냅샷을 촬영할 수 있음
- 고도화된 비교 알고리즘을 사용하기에 사용자 관점에서 테스트가 가능하다
- 다양한 운영 체제, 브라우저에서 테스트 할 수 있는 환경을 제공한다
	- 변경 이력을 모두 저장하기 때문에 수정 사항 히스토리를 파악하기도 좋음

<br/>

### 크로마틱(Chromatic)
- 스토리북 메인테이너들이 만든 시각적 회귀 테스트 도구
- 스토리북 연동이 매우 편리하기 때문에 스토리가 이미 존재한다면 시각적 회귀테스트에 활용하기 쉽다.

<br/>

### chromatic 설정하는 법
> 만약 프로젝트에 storybook이 있다면, chromatic을 쉽게 설정할 수 있다!

|설명|이미지|
|---|---|
|1. go to app 클릭|<img width="400" alt="스크린샷 2024-06-10 오후 8 18 41" src="https://github.com/KumJungMin/testcode-basic/assets/37934668/8c430b94-d89a-488d-9ab4-90cc6d70ea8c">|
|2. add to project 클릭|<img width="400" alt="스크린샷 2024-06-10 오후 8 18 55" src="https://github.com/KumJungMin/testcode-basic/assets/37934668/f34f1472-0715-4eb0-acc5-1c1abd537b61">|
|3. github project 선택|<img width="400" alt="스크린샷 2024-06-10 오후 8 19 00" src="https://github.com/KumJungMin/testcode-basic/assets/37934668/78093232-ee77-45f6-a498-f80ea2669fec">|
|4. storybook 선택|<img width="400" alt="스크린샷 2024-06-10 오후 8 19 09" src="https://github.com/KumJungMin/testcode-basic/assets/37934668/1b3ec91c-4ca2-4e9d-a489-ccb4eb03630c">|
|5. 프로젝트 크로마틱 설치|<img width="400" alt="스크린샷 2024-06-10 오후 8 19 24 복사본" src="https://github.com/KumJungMin/testcode-basic/assets/37934668/c5d98685-569c-4507-98cc-9f114d88472b">|
|6. 크로마틱 스냅샷 명령어를 packages.json에 등록하기|<img width="400" alt="스크린샷 2024-06-10 오후 8 19 24" src="https://github.com/KumJungMin/testcode-basic/assets/37934668/95ae4048-700c-4464-b7e3-bfa0563d827e">|

<br/>

### chromatic 테스트해보기
1. chromatic 명령어를 사용해 스냅샷 생성
```
"npx chromatic --project-token=크로마틱_토큰_입력"
```

그러면 chromatic 페이지에 스냅샷이 업로드됨

<img width="400" alt="스크린샷 2024-06-10 오후 7 52 06" src="https://github.com/KumJungMin/testcode-basic/assets/37934668/a5e9301d-38e3-490c-a2ec-5b1e7b8ef6a4">

<br/><br/>

2. 만약 이 상태에서 특정 컴포넌트의 색상을 변경 후 push한 뒤, ([변경 예시 코드](https://github.com/KumJungMin/testcode-basic/pull/8/commits/bdf47d43018d8df61ba691c99055c58cd2137c16))
3. 스냅샷 명령어를 재실행하면, 아래와 같이 변경점을 페이지에서 알려줌
4. 의도한 변경이라면 [변경 승인]을 클릭하면 됨

```
"npx chromatic --project-token=크로마틱_토큰_입력"
```
<img width="400" alt="스크린샷 2024-06-10 오후 7 56 37" src="https://github.com/KumJungMin/testcode-basic/assets/37934668/26034980-f541-497b-b916-abfd412940c5">


<br/><br/>

### 시각적 회귀 테스트의 한계
- 비용과 관리에 대한 부담
- 이슈의 원인을 파악하는데 오랜 시간이 걸림
	- 명확한 테스트 설명이 존재하지 않음 
- 피드백이 느림
	- 스토리북 빌드, 스냅샷 캡처, 결과 분석 시간이 소요
	- 로컬에서 실행해 바로 피드백을 받기 힘듬
	-> 시간이 오래 소요되는 테스트이기 때문에, 특정 시점에만 시각적 회귀 테스트를 실행해 피드백을 받고 확인하는 것이 효율적!
- TDD의 어려움
- 프로젝트 개발 단계에서 도입이 힘듬
	- 개발 완료시점에 도입 하되, CI는 필수로 지정할 것 